### PR TITLE
Fix core dump in clean_exit()

### DIFF
--- a/zeromerge.c
+++ b/zeromerge.c
@@ -30,7 +30,9 @@ static FILE *file1, *file2, *file3;
 
 void clean_exit(void)
 {
-	fclose(file1); fclose(file2); fclose(file3);
+	if (file1) fclose(file1);
+	if (file2) fclose(file2);
+	if (file3) fclose(file3);
 	return;
 }
 


### PR DESCRIPTION
Attemping to close file descriptor that is not opened in the first place will cause core dump.
And therefore doesn't pass tests.